### PR TITLE
Feat: News pages

### DIFF
--- a/app/callsnews/[call]/page.jsx
+++ b/app/callsnews/[call]/page.jsx
@@ -1,0 +1,58 @@
+import { newsBySlugQuery, getsettings } from '@/sanity/sanity.utils';
+import Layout from '@/app/components/Layout';
+import { componentMap } from '@/app/components/ComponentMap';
+
+export async function generateMetadata() {
+  const settings = await getsettings();
+
+  const title = `${settings?.siteTitle || ''} | Calls & News`;
+  const description = settings?.siteDescription || '';
+  const seoImage = settings?.seoImg?.asset?.url || '';
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: seoImage,
+      siteName: settings?.siteTitle || '',
+      images: [
+        {
+          url: seoImage,
+          width: 1200,
+          height: 628,
+        },
+      ],
+      locale: 'en_CA',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [seoImage],
+    },
+  };
+}
+
+export default async function Page({ params }) {
+  const { call: slug } = params;
+  const call = await newsBySlugQuery(slug);
+
+  return (
+    <Layout>
+      <div className="page-container">
+        <h1>{call.title}</h1>
+        {call.pageBlocks?.map((block) => {
+          const BlockComponent = componentMap[block._type];
+          if (!BlockComponent) {
+            console.warn(`No component for block type: ${block._type}`);
+            return null;
+          }
+          return <BlockComponent key={block._key} value={block} />;
+        })}
+      </div>
+    </Layout>
+  );
+}

--- a/app/callsnews/page.jsx
+++ b/app/callsnews/page.jsx
@@ -1,0 +1,69 @@
+import { getNews, getsettings } from '@/sanity/sanity.utils';
+import Layout from '@/app/components/Layout';
+import NewsCard from '@/app/components/NewsCard';
+
+export async function generateMetadata() {
+  const settings = await getsettings();
+
+  const title = `${settings?.siteTitle || ''} | Calls & News`;
+  const description = settings?.siteDescription || '';
+  const seoImage = settings?.seoImg?.asset?.url || '';
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: seoImage,
+      siteName: settings?.siteTitle || '',
+      images: [
+        {
+          url: seoImage,
+          width: 1200,
+          height: 628,
+        },
+      ],
+      locale: 'en_CA',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [seoImage],
+    },
+  };
+}
+
+export default async function Page() {
+  const news = await getNews();
+
+  const currentCalls = news.filter((item) =>
+    item.isPostActive?.includes('current')
+  );
+  const pastCalls = news.filter((item) => item.isPostActive?.includes('past'));
+
+  return (
+    <Layout>
+      <h1>Current Calls / News</h1>
+      {currentCalls?.map((call, index) => (
+        <NewsCard
+          key={call._id ?? index}
+          title={call.title}
+          slug={call.slug.current}
+          description={call.pageDesc}
+        />
+      ))}
+      <h2>Past Calls</h2>
+      {pastCalls?.map((call, index) => (
+        <NewsCard
+          key={call._id ?? index}
+          title={call.title}
+          slug={call.slug.current}
+          description={call.pageDesc}
+        />
+      ))}
+    </Layout>
+  );
+}

--- a/app/components/NewsCard.jsx
+++ b/app/components/NewsCard.jsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+import { PortableText } from '@portabletext/react';
+
+const linkResolver = (link) => {
+  if (!link) {
+    return null;
+  }
+  const isExternalLink = link?.startsWith('http');
+  if (isExternalLink) {
+    return link;
+  }
+
+  if (link?.includes('callsnews')) {
+    return `/${link}`;
+  }
+
+  return `callsnews/${link}`;
+};
+export default function NewsCard({ title, slug, description }) {
+  const link = linkResolver(slug);
+  return (
+    <section className="hero-container">
+      <h2 className="news-title">{title}</h2>
+      {description && (
+        <div className="news-description">
+          <PortableText value={description} />
+        </div>
+      )}
+      {link && (
+        <Link href={link} className="news-link">
+          Learn More
+        </Link>
+      )}
+    </section>
+  );
+}

--- a/sanity/sanity.utils.js
+++ b/sanity/sanity.utils.js
@@ -301,9 +301,10 @@ export async function getNews() {
   return createClient(clientConfig).fetch(
     groq`
       *[_type == "news"] {
-       title,
-      slug,
-      pageDesc,
+        title,
+        slug,
+        pageDesc,
+        isPostActive
     }
   `
   )

--- a/sanity/schemas/news.js
+++ b/sanity/schemas/news.js
@@ -36,7 +36,7 @@ export default {
           { type: 'ctaButton'},
           { type: 'gallery' },
           { type: 'hero' },
-          {type: 'headingText'},
+          { type: 'headingText'},
           {type: 'logoContainer'},
           { type: 'imageCarousel' },
           { type: 'imageCustom' },
@@ -49,6 +49,19 @@ export default {
         name: 'seo',
         title: 'SEO',
         type: 'seo'
+      },
+      {
+        name: 'isPostActive',
+        title: 'Active Post',
+        type: 'array',
+        of: [{ type: 'string' }],
+        options: {
+          list: [
+            { title: 'Current', value: 'current' },
+            { title: 'Past', value: 'past' },
+          ]
+        },
+        validation: Rule => Rule.required().min(1)
       }
     ],
     preview: {


### PR DESCRIPTION
- 2 new pages: `/callsnews`, `/callsnews/<post>`
- `/callsnews` has current and past calls
- Create NewsCards component
-  `/callsnews/<post>` page has title and content blocks boilerplate